### PR TITLE
Fix Clippy Lints

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,10 @@ jobs:
       # Shrink artifact size by not including debug info. Makes build faster and shrinks cache.
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
+      # Error build on warning (including clippy lints)
+      RUSTFLAGS: "-Dwarnings"
     steps:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v1
       - run: cargo test
+      - run: cargo clippy

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Result};
 use ethers::types::Address;
 use log::debug;
 use std::env;
@@ -22,13 +22,16 @@ impl Configuration {
         let node_base_url = collect_optional_environment_variable("NODE_BASE_URL")?;
 
         if infura_api_key.is_none() && node_base_url.is_none() {
-            return Err(anyhow!("either `infura_api_key` or `node_base_url` must be set"))
+            return Err(anyhow!(
+                "either `infura_api_key` or `node_base_url` must be set"
+            ));
         }
 
         let network = collect_optional_environment_variable("MILKMAN_NETWORK")?
-            .unwrap_or("mainnet".to_string());
+            .unwrap_or_else(|| "mainnet".to_string());
         let milkman_address = collect_optional_environment_variable("MILKMAN_ADDRESS")?
-            .unwrap_or(PROD_MILKMAN_ADDRESS.to_string())
+            .as_deref()
+            .unwrap_or(PROD_MILKMAN_ADDRESS)
             .parse()?;
         let polling_frequency_secs =
             collect_optional_environment_variable("POLLING_FREQUENCY_SECS")?
@@ -36,7 +39,8 @@ impl Configuration {
                 .transpose()?
                 .unwrap_or(10);
         let hash_helper_address = collect_optional_environment_variable("HASH_HELPER_ADDRESS")?
-            .unwrap_or(MAINNET_HASH_HELPER_ADDRESS.to_string())
+            .as_deref()
+            .unwrap_or(MAINNET_HASH_HELPER_ADDRESS)
             .parse()?;
 
         let starting_block_number =
@@ -55,10 +59,6 @@ impl Configuration {
             node_base_url,
         })
     }
-}
-
-fn collect_required_environment_variable(key: &str) -> Result<String> {
-    Ok(env::var(key).context(format!("required environment variable {} not set", key))?)
 }
 
 fn collect_optional_environment_variable(key: &str) -> Result<Option<String>> {

--- a/src/cow_api_client.rs
+++ b/src/cow_api_client.rs
@@ -1,5 +1,5 @@
 use crate::configuration::Configuration;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use ethers::abi::Address;
 use ethers::types::{Bytes, U256};
 use log::{debug, info};
@@ -12,6 +12,19 @@ pub struct Quote {
     pub fee_amount: U256,
     pub buy_amount_after_fee: U256,
     pub valid_to: u64,
+}
+
+#[derive(Debug)]
+pub struct Order<'a> {
+    pub order_contract: Address,
+    pub sell_token: Address,
+    pub buy_token: Address,
+    pub sell_amount: U256,
+    pub buy_amount: U256,
+    pub valid_to: u64,
+    pub fee_amount: U256,
+    pub receiver: Address,
+    pub eip_1271_signature: &'a Bytes,
 }
 
 pub struct CowAPIClient {
@@ -73,15 +86,15 @@ impl CowAPIClient {
         let quote = &response_body["quote"];
         let fee_amount = quote["feeAmount"]
             .as_str()
-            .ok_or(anyhow!("unable to get `feeAmount` on quote"))?
+            .context("unable to get `feeAmount` on quote")?
             .to_owned();
         let buy_amount_after_fee = quote["buyAmount"]
             .as_str()
-            .ok_or(anyhow!("unable to get `buyAmountAfterFee` from quote"))?
+            .context("unable to get `buyAmountAfterFee` from quote")?
             .to_owned();
         let valid_to = quote["validTo"]
             .as_u64()
-            .ok_or(anyhow!("unable to get `validTo` from quote"))?;
+            .context("unable to get `validTo` from quote")?;
 
         Ok(Quote {
             fee_amount: fee_amount.parse::<u128>()?.into(),
@@ -92,15 +105,17 @@ impl CowAPIClient {
 
     pub async fn create_order(
         &self,
-        order_contract: Address,
-        sell_token: Address,
-        buy_token: Address,
-        sell_amount: U256,
-        buy_amount: U256,
-        valid_to: u64,
-        fee_amount: U256,
-        receiver: Address,
-        eip_1271_signature: &Bytes,
+        Order {
+            order_contract,
+            sell_token,
+            buy_token,
+            sell_amount,
+            buy_amount,
+            valid_to,
+            fee_amount,
+            receiver,
+            eip_1271_signature,
+        }: Order<'_>,
     ) -> Result<String> {
         let http_client = reqwest::Client::new();
         let response = http_client
@@ -130,7 +145,7 @@ impl CowAPIClient {
                 .json::<Value>()
                 .await?
                 .as_str()
-                .ok_or(anyhow!("Unable to retrieve UID from POST order response"))?
+                .context("Unable to retrieve UID from POST order response")?
                 .to_string(),
             Err(err) => {
                 debug!("POST order failed with body: {:?}", response.text().await?);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -4,17 +4,33 @@ use hex::FromHex;
 
 use crate::constants::{APP_DATA, ERC20_BALANCE, KIND_SELL};
 
+#[derive(Debug)]
+pub struct SignatureData<'a> {
+    pub from_token: Address,
+    pub to_token: Address,
+    pub receiver: Address,
+    pub sell_amount_after_fees: U256,
+    pub buy_amount_after_fees_and_slippage: U256,
+    pub valid_to: u64,
+    pub fee_amount: U256,
+    pub order_creator: Address,
+    pub price_checker: Address,
+    pub price_checker_data: &'a Bytes,
+}
+
 pub fn get_eip_1271_signature(
-    from_token: Address,
-    to_token: Address,
-    receiver: Address,
-    sell_amount_after_fees: U256,
-    buy_amount_after_fees_and_slippage: U256,
-    valid_to: u64,
-    fee_amount: U256,
-    order_creator: Address,
-    price_checker: Address,
-    price_checker_data: &Bytes,
+    SignatureData {
+        from_token,
+        to_token,
+        receiver,
+        sell_amount_after_fees,
+        buy_amount_after_fees_and_slippage,
+        valid_to,
+        fee_amount,
+        order_creator,
+        price_checker,
+        price_checker_data,
+    }: SignatureData<'_>,
 ) -> Bytes {
     abi::encode(&vec![
         Token::Address(from_token),

--- a/src/ethereum_client.rs
+++ b/src/ethereum_client.rs
@@ -1,5 +1,4 @@
-use crate::types::{BlockNumber, Swap};
-use anyhow::{anyhow, Result};
+use anyhow::{Context, Result};
 use ethers::prelude::*;
 use hex::FromHex;
 use log::debug;
@@ -10,7 +9,8 @@ use std::sync::Arc;
 
 use crate::configuration::Configuration;
 use crate::constants::{APP_DATA, ERC20_BALANCE, KIND_SELL};
-use crate::encoder;
+use crate::encoder::{self, SignatureData};
+use crate::types::{BlockNumber, Swap};
 
 abigen!(
     RawMilkman,
@@ -46,7 +46,8 @@ impl EthereumClient {
         } else {
             format!(
                 "https://{}.infura.io/v3/{}",
-                config.network, config.infura_api_key.clone().unwrap()
+                config.network,
+                config.infura_api_key.clone().unwrap()
             )
         };
         let provider = Arc::new(Provider::<Http>::try_from(node_url)?);
@@ -61,10 +62,11 @@ impl EthereumClient {
         self.get_latest_block()
             .await?
             .number
-            .ok_or(anyhow!("Error extracting number from latest block."))
+            .context("Error extracting number from latest block.")
             .map(|block_num: U64| block_num.try_into().unwrap()) // U64 -> u64 should always work
     }
 
+    #[cfg(test)]
     pub async fn get_chain_timestamp(&self) -> Result<u64> {
         Ok(self.get_latest_block().await?.timestamp.as_u64())
     }
@@ -73,7 +75,7 @@ impl EthereumClient {
         self.inner_client
             .get_block(ethers::core::types::BlockNumber::Latest)
             .await?
-            .ok_or(anyhow!("Error fetching latest block."))
+            .context("Error fetching latest block.")
     }
 
     pub async fn get_requested_swaps(
@@ -135,18 +137,18 @@ impl EthereumClient {
             .call()
             .await?;
 
-        let mock_signature = encoder::get_eip_1271_signature(
-            swap_request.from_token,
-            swap_request.to_token,
-            swap_request.receiver,
-            swap_request.amount_in,
-            U256::MAX,
-            u32::MAX as u64,
-            U256::zero(),
-            swap_request.order_creator,
-            swap_request.price_checker,
-            &swap_request.price_checker_data,
-        );
+        let mock_signature = encoder::get_eip_1271_signature(SignatureData {
+            from_token: swap_request.from_token,
+            to_token: swap_request.to_token,
+            receiver: swap_request.receiver,
+            sell_amount_after_fees: swap_request.amount_in,
+            buy_amount_after_fees_and_slippage: U256::MAX,
+            valid_to: u32::MAX as u64,
+            fee_amount: U256::zero(),
+            order_creator: swap_request.order_creator,
+            price_checker: swap_request.price_checker,
+            price_checker_data: &swap_request.price_checker_data,
+        });
 
         debug!(
             "Is valid sig? {:?}",
@@ -161,7 +163,6 @@ impl EthereumClient {
             .estimate_gas()
             .await?)
     }
-
 }
 
 impl From<&SwapRequestedFilter> for Swap {


### PR DESCRIPTION
This PR just fixes a few clippy lints that I detected when building locally. Namely:
- `dead_code`: a couple of unused functions
- [`clippy::or_fun_call`](https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call)
- [`clippy::needless_question_mark`](https://rust-lang.github.io/rust-clippy/master/index.html#needless_question_mark)
- [`clippy::too_many_arguments`](https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments)

Also ran `cargo fmt`