### PR TITLE
Add Docker Deployment Workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,37 @@
+name: deploy
+on:
+  push:
+    branches: [main]
+    tags: [v*]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Metadata
+        id: meta_services
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository }}
+          labels: |
+            org.opencontainers.image.licenses=UNLICENSED
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta_services.outputs.tags }}
+          labels: ${{ steps.meta_services.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,23 +8,25 @@ RUN apt-get update && apt-get install -y git libssl-dev pkg-config
 COPY Cargo.toml /tmp/milkman-bot
 COPY Cargo.lock /tmp/milkman-bot
 
+ENV CARGO_PROFILE_RELEASE_DEBUG=1
+
 # To cache dependencies, create a layer that compiles dependencies and some rust src that won't change, 
 # and then another layer that compiles our source.
 RUN echo 'fn main() {}' >> /tmp/milkman-bot/dummy.rs
 
 RUN sed -i 's|src/main.rs|dummy.rs|g' Cargo.toml
-RUN env CARGO_PROFILE_RELEASE_DEBUG=1 cargo build --release
+RUN cargo build --release
 
 RUN sed -i 's|dummy.rs|src/main.rs|g' Cargo.toml
 COPY . /tmp/milkman-bot
-RUN env CARGO_PROFILE_RELEASE_DEBUG=1 cargo build --release
+RUN cargo build --release
 
-FROM docker.io/debian:stable
+FROM docker.io/debian:bullseye-slim
 
-COPY --from=cargo-build /tmp/milkman-bot/target/release/milkman-bot /
-COPY --from=cargo-build /tmp/milkman-bot /project/
+COPY --from=cargo-build /tmp/milkman-bot/target/release/milkman-bot /usr/bin/
 WORKDIR /
 
-RUN apt-get update && apt-get install -y libssl-dev git
+RUN apt-get update && apt-get install -y ca-certificates tini
 
-CMD ["./milkman-bot"]
+ENTRYPOINT ["tini", "--"]
+CMD ["milkman-bot"]


### PR DESCRIPTION
This PR adds a new GitHub Action to build and deploy a Docker image to the GitHub Container Registry (GHCR).

The way the workflow is setup, every push to `main` will deploy a new `ghcr.io/charlesndalton/milkman-bot:main` image and every `v*` tag will deploy a `ghcr.io/charlesndalton/milkman-bot:v*` and `ghcr.io/charlesndalton/milkman-bot:latest` image (so `latest` always points to the latest release).

I also tweaked the Docker image a bit:
- Use `bullseye-slim` for a smaller image
- Only install `ca-certificates` and not SSL development headers with it. This should be enough for the linked `openssl` to work (tested locally and it was the case).
- Install `tini` - this is just an `init` process for Docker containers, it has some nice things like handling `Ctrl+C`

### Test Plan

Built and ran the image locally:
```
% docker build . -t milkman
...
% docker run -it --rm -e INFURA_API_KEY=noneofyourbusiness -e RUST_LOG=debug milkman
[2023-01-31T09:42:13Z INFO  milkman_bot] === MILKMAN BOT STARTING ===
[2023-01-31T09:42:13Z DEBUG milkman_bot::configuration] environment variable NODE_BASE_URL not set but it wasn't required
[2023-01-31T09:42:13Z DEBUG milkman_bot::configuration] environment variable MILKMAN_NETWORK not set but it wasn't required
[2023-01-31T09:42:13Z DEBUG milkman_bot::configuration] environment variable MILKMAN_ADDRESS not set but it wasn't required
[2023-01-31T09:42:13Z DEBUG milkman_bot::configuration] environment variable POLLING_FREQUENCY_SECS not set but it wasn't required
[2023-01-31T09:42:13Z DEBUG milkman_bot::configuration] environment variable HASH_HELPER_ADDRESS not set but it wasn't required
[2023-01-31T09:42:13Z DEBUG milkman_bot::configuration] environment variable STARTING_BLOCK_NUMBER not set but it wasn't required
[2023-01-31T09:42:14Z DEBUG reqwest::connect] starting new connection: https://mainnet.infura.io/
[2023-01-31T09:42:14Z DEBUG milkman_bot] range start: 16525979
[2023-01-31T09:42:24Z DEBUG milkman_bot] range end: 16525980
```

Also, some very nice image size improvements:
```
REPOSITORY                                TAG       IMAGE ID       CREATED          SIZE
milkman                                   main      62085f40fcd3   24 minutes ago   4.32GB
milkman                                   new       f03a4da23a31   2 hours ago      208MB
```