### PR TITLE
Debug failing placement

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -14,6 +14,7 @@ pub struct Configuration {
     pub starting_block_number: Option<u64>,
     pub polling_frequency_secs: u64,
     pub node_base_url: Option<String>,
+    pub slippage_tolerance_bps: u16,
 }
 
 impl Configuration {
@@ -49,6 +50,12 @@ impl Configuration {
                 None => None,
             };
 
+        let slippage_tolerance_bps =
+            match collect_optional_environment_variable("SLIPPAGE_TOLERANCE_BPS")? {
+                Some(block_num) => block_num.parse::<u16>().expect("Unable to parse slippage tolerance factor"),
+                None => 50,
+            };
+
         Ok(Self {
             infura_api_key,
             network,
@@ -57,6 +64,7 @@ impl Configuration {
             starting_block_number,
             polling_frequency_secs,
             node_base_url,
+            slippage_tolerance_bps
         })
     }
 }

--- a/src/cow_api_client.rs
+++ b/src/cow_api_client.rs
@@ -12,6 +12,7 @@ pub struct Quote {
     pub fee_amount: U256,
     pub buy_amount_after_fee: U256,
     pub valid_to: u64,
+    pub id: u64,
 }
 
 #[derive(Debug)]
@@ -95,11 +96,15 @@ impl CowAPIClient {
         let valid_to = quote["validTo"]
             .as_u64()
             .context("unable to get `validTo` from quote")?;
+        let id = response_body["id"]
+            .as_u64()
+            .context("unable to get `id` from quote")?;
 
         Ok(Quote {
             fee_amount: fee_amount.parse::<u128>()?.into(),
             buy_amount_after_fee: buy_amount_after_fee.parse::<u128>()?.into(),
             valid_to,
+            id
         })
     }
 
@@ -116,6 +121,7 @@ impl CowAPIClient {
             receiver,
             eip_1271_signature,
         }: Order<'_>,
+        quote_id: u64
     ) -> Result<String> {
         let http_client = reqwest::Client::new();
         let response = http_client
@@ -135,7 +141,8 @@ impl CowAPIClient {
                 "from": order_contract,
                 "sellTokenBalance": "erc20",
                 "buyTokenBalance": "erc20",
-                "signingScheme": "eip1271"
+                "signingScheme": "eip1271",
+                "quoteId": quote_id,
             }))
             .send()
             .await?;

--- a/src/ethereum_client.rs
+++ b/src/ethereum_client.rs
@@ -150,6 +150,7 @@ impl EthereumClient {
             price_checker_data: &swap_request.price_checker_data,
         });
 
+        debug!("isValidSignature({:?},{:?})", hex::encode(&mock_order_digest), hex::encode(&mock_signature.0));
         debug!(
             "Is valid sig? {:?}",
             order_contract

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,7 +151,7 @@ async fn main() {
                 };
 
                 let sell_amount_after_fees = requested_swap.amount_in - quote.fee_amount;
-                let buy_amount_after_fees_and_slippage = quote.buy_amount_after_fee * 995 / 1000;
+                let buy_amount_after_fees_and_slippage = quote.buy_amount_after_fee * (10000 - config.slippage_tolerance_bps / 10000);
 
                 let eip_1271_signature = encoder::get_eip_1271_signature(SignatureData {
                     from_token: requested_swap.from_token,

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,7 @@ async fn main() {
                         fee_amount: quote.fee_amount,
                         receiver: requested_swap.receiver,
                         eip_1271_signature: &eip_1271_signature,
-                    })
+                    }, quote.id)
                     .await
                 {
                     Ok(_) => (),


### PR DESCRIPTION
Local code changes to easier debug why order placement is not working. Also contains code to set a custom slippage tolerance and use the quoteID we get from the API when placing the order.