### PR TITLE
Make slippage tolerance configurable

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -14,6 +14,7 @@ pub struct Configuration {
     pub starting_block_number: Option<u64>,
     pub polling_frequency_secs: u64,
     pub node_base_url: Option<String>,
+    pub slippage_tolerance_bps: u16,
 }
 
 impl Configuration {
@@ -49,6 +50,12 @@ impl Configuration {
                 None => None,
             };
 
+        let slippage_tolerance_bps =
+            match collect_optional_environment_variable("SLIPPAGE_TOLERANCE_BPS")? {
+                Some(block_num) => block_num.parse::<u16>().expect("Unable to parse slippage tolerance factor"),
+                None => 50,
+            };
+
         Ok(Self {
             infura_api_key,
             network,
@@ -57,6 +64,7 @@ impl Configuration {
             starting_block_number,
             polling_frequency_secs,
             node_base_url,
+            slippage_tolerance_bps
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,7 +151,7 @@ async fn main() {
                 };
 
                 let sell_amount_after_fees = requested_swap.amount_in - quote.fee_amount;
-                let buy_amount_after_fees_and_slippage = quote.buy_amount_after_fee * 995 / 1000;
+                let buy_amount_after_fees_and_slippage = quote.buy_amount_after_fee * (10000 - config.slippage_tolerance_bps / 10000);
 
                 let eip_1271_signature = encoder::get_eip_1271_signature(SignatureData {
                     from_token: requested_swap.from_token,


### PR DESCRIPTION
Currently, the slippage tolerance is hardcoded to use 0.5% but depending on the price checker, project may want to configure they trade with less slippage (e.g. for stablecoin trades).

This PR makes the slippage tolerance configurable via a parameter, so that it's easy for projects to run their own bot with tolerance catered to their needs.