### PR TITLE
[Trivial] Debug print isValidSignature call

### DIFF
--- a/src/ethereum_client.rs
+++ b/src/ethereum_client.rs
@@ -150,6 +150,7 @@ impl EthereumClient {
             price_checker_data: &swap_request.price_checker_data,
         });
 
+        debug!("isValidSignature({:?},{:?})", hex::encode(&mock_order_digest), hex::encode(&mock_signature.0));
         debug!(
             "Is valid sig? {:?}",
             order_contract


### PR DESCRIPTION
Adding a debug print to make it very easy to reproduce the `isValidSignature` call that is made to the milkman order (for debugging purposes)