### PR TITLE
Use quoteId when placing orders

### DIFF
--- a/src/cow_api_client.rs
+++ b/src/cow_api_client.rs
@@ -12,6 +12,7 @@ pub struct Quote {
     pub fee_amount: U256,
     pub buy_amount_after_fee: U256,
     pub valid_to: u64,
+    pub id: u64,
 }
 
 #[derive(Debug)]
@@ -95,11 +96,15 @@ impl CowAPIClient {
         let valid_to = quote["validTo"]
             .as_u64()
             .context("unable to get `validTo` from quote")?;
+        let id = response_body["id"]
+            .as_u64()
+            .context("unable to get `id` from quote")?;
 
         Ok(Quote {
             fee_amount: fee_amount.parse::<u128>()?.into(),
             buy_amount_after_fee: buy_amount_after_fee.parse::<u128>()?.into(),
             valid_to,
+            id
         })
     }
 
@@ -116,6 +121,7 @@ impl CowAPIClient {
             receiver,
             eip_1271_signature,
         }: Order<'_>,
+        quote_id: u64
     ) -> Result<String> {
         let http_client = reqwest::Client::new();
         let response = http_client
@@ -135,7 +141,8 @@ impl CowAPIClient {
                 "from": order_contract,
                 "sellTokenBalance": "erc20",
                 "buyTokenBalance": "erc20",
-                "signingScheme": "eip1271"
+                "signingScheme": "eip1271",
+                "quoteId": quote_id,
             }))
             .send()
             .await?;

--- a/src/cow_api_client.rs
+++ b/src/cow_api_client.rs
@@ -26,6 +26,7 @@ pub struct Order<'a> {
     pub fee_amount: U256,
     pub receiver: Address,
     pub eip_1271_signature: &'a Bytes,
+    pub quote_id: u64,
 }
 
 pub struct CowAPIClient {
@@ -104,7 +105,7 @@ impl CowAPIClient {
             fee_amount: fee_amount.parse::<u128>()?.into(),
             buy_amount_after_fee: buy_amount_after_fee.parse::<u128>()?.into(),
             valid_to,
-            id
+            id,
         })
     }
 
@@ -120,8 +121,8 @@ impl CowAPIClient {
             fee_amount,
             receiver,
             eip_1271_signature,
+            quote_id,
         }: Order<'_>,
-        quote_id: u64
     ) -> Result<String> {
         let http_client = reqwest::Client::new();
         let response = http_client

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,7 @@ async fn main() {
                         fee_amount: quote.fee_amount,
                         receiver: requested_swap.receiver,
                         eip_1271_signature: &eip_1271_signature,
-                    })
+                    }, quote.id)
                     .await
                 {
                     Ok(_) => (),

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,8 @@ async fn main() {
                         fee_amount: quote.fee_amount,
                         receiver: requested_swap.receiver,
                         eip_1271_signature: &eip_1271_signature,
-                    }, quote.id)
+                        quote_id: quote.id,
+                    })
                     .await
                 {
                     Ok(_) => (),


### PR DESCRIPTION
The backend API sends us a quoteId for our order placement which we can use to help the backend "find" the quoted fee it gave us and therefore reduce the chance our order gets rejected for "insufficient fee" (ie e.g. the gas price increased between quoting and placing the order).

The current behavior is not a big deal, but this seems slightly more correct.