### PR TITLE
Switch to tracing logs to allow for log spans per order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,19 +798,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "eth-keystore"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1527,12 +1514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,6 +1773,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,7 +1810,6 @@ name = "milkman-bot"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "env_logger",
  "ethers",
  "hex",
  "log",
@@ -1829,6 +1818,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -1882,6 +1873,16 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-integer"
@@ -1995,6 +1996,12 @@ name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parity-scale-codec"
@@ -2428,6 +2435,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,6 +2846,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,6 +3105,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3246,6 +3281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -3256,6 +3292,35 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3367,6 +3432,12 @@ dependencies = [
  "getrandom",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ serde = "1.0"
 serde_json = "1.0"
 hex = "0.4.3"
 log = "0.4"
-env_logger = "0.8.4"
 anyhow = "1.0.61"
 ethers = { version = "0.17.0", features = ["abigen", "openssl"] }
 url = { version = "2.2.2" }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [dev-dependencies]
 rand = { version = "0.8.4", features = ["min_const_gen"] }

--- a/src/ethereum_client.rs
+++ b/src/ethereum_client.rs
@@ -241,7 +241,7 @@ mod tests {
             .await
             .expect("Unable to get requested swaps");
 
-        assert!(requested_swaps.len() > 0);
+        assert!(!requested_swaps.is_empty());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use hex::ToHex;
-use log::{debug, error, info};
 use std::{collections::HashMap, time::Duration};
 use tokio::time::sleep;
+use tracing::Instrument;
 
 mod configuration;
 use crate::configuration::Configuration;
@@ -32,9 +32,8 @@ mod constants;
 /// marginal cloud compute cost to CoW is likely to be very small.
 #[tokio::main]
 async fn main() {
-    env_logger::init();
-
-    info!("=== MILKMAN BOT STARTING ===");
+    tracing_subscriber::fmt::init();
+    tracing::info!("=== MILKMAN BOT STARTING ===");
 
     let config = Configuration::get_from_environment()
         .expect("Unable to get configuration from the environment variables."); // .expect() because every decision to panic should be conscious, not just triggered by a `?` that we didn't think about
@@ -56,7 +55,7 @@ async fn main() {
             .expect("Unable to get latest block number before starting."),
     );
 
-    debug!("range start: {}", range_start);
+    tracing::debug!("range start: {}", range_start);
 
     let mut swap_queue = HashMap::new();
 
@@ -68,7 +67,7 @@ async fn main() {
             .await
             .expect("Unable to get latest block number."); // should we panic here if we can't get it? another option would be continuing in the loop, but then we might not observe that the bot is really `down`
 
-        debug!("range end: {}", range_end);
+        tracing::debug!("range end: {}", range_end);
 
         // add the - 100 to cast a wider net since Infura sometimes doesn't reply
         let requested_swaps = match eth_client
@@ -77,13 +76,13 @@ async fn main() {
         {
             Ok(swaps) => swaps,
             Err(err) => {
-                error!("unable to get requested swaps – {:?}", err);
+                tracing::error!("unable to get requested swaps – {:?}", err);
                 continue;
             }
         };
 
         if !requested_swaps.is_empty() {
-            info!(
+            tracing::info!(
                 "Found {} requested swaps between blocks {} and {}",
                 requested_swaps.len(),
                 range_start,
@@ -92,8 +91,8 @@ async fn main() {
         }
 
         for requested_swap in requested_swaps {
-            info!("Inserting following swap in queue: {:?}", requested_swap);
-            debug!(
+            tracing::info!("Inserting following swap in queue: {:?}", requested_swap);
+            tracing::debug!(
                 "Price checker data hex: 0x{}",
                 requested_swap.price_checker_data.encode_hex::<String>()
             );
@@ -104,95 +103,110 @@ async fn main() {
             let is_swap_fulfilled = match is_swap_fulfilled(requested_swap, &eth_client).await {
                 Ok(res) => res,
                 Err(err) => {
-                    error!("unable to determine if swap was fulfilled – {:?}", err);
+                    tracing::error!("unable to determine if swap was fulfilled – {:?}", err);
                     continue;
                 }
             };
 
             if is_swap_fulfilled {
-                info!(
+                tracing::info!(
                     "Swap with order contract ({}) was fulfilled, removing from queue.",
                     requested_swap.order_contract
                 );
                 swap_queue.remove(&requested_swap.order_contract);
             } else {
-                info!(
-                    "Handling swap with order contract ({})",
-                    requested_swap.order_contract
-                );
-                let mut verification_gas_limit = match eth_client
-                    .get_estimated_order_contract_gas(&config, requested_swap)
-                    .await
-                {
-                    Ok(res) => res,
-                    Err(err) => {
-                        error!("unable to estimate verification gas – {:?}", err);
-                        continue;
+                let contract = format!("{:#x}", requested_swap.order_contract);
+                async {
+                    if let Err(err) =
+                        handle_swap(requested_swap, &eth_client, &cow_api_client, &config).await
+                    {
+                        tracing::error!("unable to handle swap {:?}", err);
                     }
-                };
-                verification_gas_limit = (verification_gas_limit * 11) / 10; // extra padding
-                debug!(
-                    "verification gas limit to use - {:?}",
-                    verification_gas_limit
-                );
-
-                let quote = match cow_api_client
-                    .get_quote(
-                        requested_swap.order_contract,
-                        requested_swap.from_token,
-                        requested_swap.to_token,
-                        requested_swap.amount_in,
-                        verification_gas_limit.as_u64(),
-                    )
-                    .await
-                {
-                    Ok(res) => res,
-                    Err(err) => {
-                        error!("unable to fetch quote - {:?}", err);
-                        continue;
-                    }
-                };
-
-                let sell_amount_after_fees = requested_swap.amount_in - quote.fee_amount;
-                let buy_amount_after_fees_and_slippage =
-                    quote.buy_amount_after_fee * (10000 - config.slippage_tolerance_bps) / 10000;
-
-                let eip_1271_signature = encoder::get_eip_1271_signature(SignatureData {
-                    from_token: requested_swap.from_token,
-                    to_token: requested_swap.to_token,
-                    receiver: requested_swap.receiver,
-                    sell_amount_after_fees,
-                    buy_amount_after_fees_and_slippage,
-                    valid_to: quote.valid_to,
-                    fee_amount: quote.fee_amount,
-                    order_creator: requested_swap.order_creator,
-                    price_checker: requested_swap.price_checker,
-                    price_checker_data: &requested_swap.price_checker_data,
-                });
-
-                match cow_api_client
-                    .create_order(Order {
-                        order_contract: requested_swap.order_contract,
-                        sell_token: requested_swap.from_token,
-                        buy_token: requested_swap.to_token,
-                        sell_amount: sell_amount_after_fees,
-                        buy_amount: buy_amount_after_fees_and_slippage,
-                        valid_to: quote.valid_to,
-                        fee_amount: quote.fee_amount,
-                        receiver: requested_swap.receiver,
-                        eip_1271_signature: &eip_1271_signature,
-                        quote_id: quote.id,
-                    })
-                    .await
-                {
-                    Ok(_) => (),
-                    Err(err) => error!("unable to create order via CoW API – {:?}", err),
-                };
+                }
+                .instrument(tracing::info_span!("handle_swap", contract))
+                .await
             }
         }
 
         range_start = range_end;
     }
+}
+
+async fn handle_swap(
+    requested_swap: &Swap,
+    eth_client: &EthereumClient,
+    cow_api_client: &CowAPIClient,
+    config: &Configuration,
+) -> Result<()> {
+    tracing::info!(
+        "Handling swap with order contract ({})",
+        requested_swap.order_contract
+    );
+    let mut verification_gas_limit = match eth_client
+        .get_estimated_order_contract_gas(&config, requested_swap)
+        .await
+    {
+        Ok(res) => res,
+        Err(err) => {
+            bail!("unable to estimate verification gas – {:?}", err);
+        }
+    };
+    verification_gas_limit = (verification_gas_limit * 11) / 10; // extra padding
+    tracing::debug!(
+        "verification gas limit to use - {:?}",
+        verification_gas_limit
+    );
+
+    let quote = match cow_api_client
+        .get_quote(
+            requested_swap.order_contract,
+            requested_swap.from_token,
+            requested_swap.to_token,
+            requested_swap.amount_in,
+            verification_gas_limit.as_u64(),
+        )
+        .await
+    {
+        Ok(res) => res,
+        Err(err) => {
+            bail!("unable to fetch quote - {:?}", err);
+        }
+    };
+
+    let sell_amount_after_fees = requested_swap.amount_in - quote.fee_amount;
+    let buy_amount_after_fees_and_slippage =
+        quote.buy_amount_after_fee * (10000 - config.slippage_tolerance_bps) / 10000;
+
+    let eip_1271_signature = encoder::get_eip_1271_signature(SignatureData {
+        from_token: requested_swap.from_token,
+        to_token: requested_swap.to_token,
+        receiver: requested_swap.receiver,
+        sell_amount_after_fees,
+        buy_amount_after_fees_and_slippage,
+        valid_to: quote.valid_to,
+        fee_amount: quote.fee_amount,
+        order_creator: requested_swap.order_creator,
+        price_checker: requested_swap.price_checker,
+        price_checker_data: &requested_swap.price_checker_data,
+    });
+    tracing::debug!(signature = ?eip_1271_signature.to_string());
+
+    cow_api_client
+        .create_order(Order {
+            order_contract: requested_swap.order_contract,
+            sell_token: requested_swap.from_token,
+            buy_token: requested_swap.to_token,
+            sell_amount: sell_amount_after_fees,
+            buy_amount: buy_amount_after_fees_and_slippage,
+            valid_to: quote.valid_to,
+            fee_amount: quote.fee_amount,
+            receiver: requested_swap.receiver,
+            eip_1271_signature: &eip_1271_signature,
+            quote_id: quote.id,
+        })
+        .await
+        .context("unable to create order via CoW API")?;
+    Ok(())
 }
 
 async fn is_swap_fulfilled(swap: &Swap, eth_client: &EthereumClient) -> Result<bool> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ async fn handle_swap(
         requested_swap.order_contract
     );
     let mut verification_gas_limit = match eth_client
-        .get_estimated_order_contract_gas(&config, requested_swap)
+        .get_estimated_order_contract_gas(config, requested_swap)
         .await
     {
         Ok(res) => res,


### PR DESCRIPTION
Tracing logs allow for log spans which make it easier to search for logs that concern e.g. a specific order contract in our logging tool.

This PR changes from `env_logger` to `tracing` and moves the logic to handle each requested swap into its own method which we then instrument with a logging span. The result is that logs now look like this:

```
2023-08-26T20:26:30.906439Z  INFO handle_swap{contract="0xe09a7a0eb158a983ff1c03a68548ad24ef3dc6eb"}: milkman_bot: Handling swap with order contract (0xe09a…c6eb)
2023-08-26T20:26:31.233278Z ERROR handle_swap{contract="0xe09a7a0eb158a983ff1c03a68548ad24ef3dc6eb"}: milkman_bot: unable to handle swap unable to estimate verification gas – (code: -32000, message: execution reverted, data: None)
```

making it very easy to grep for logs for a specific order.